### PR TITLE
feat: v0.5.0 (#35)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-      - develop
+      - dev/*
   pull_request:
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,17 @@ find_package(SFML CONFIG REQUIRED COMPONENTS Graphics Window System)
 add_executable(game 
     src/main.cpp
     src/Card.cpp
+    src/CardManager.cpp
     src/Deck.cpp
+    src/Game.cpp
     src/Potager.cpp
+    src/PlayerHand.cpp
+    src/Garbage.cpp
     src/InputManager.cpp
-    src/TextureManager.cpp)
+    src/TextureManager.cpp
+    src/FontManager.cpp
+    src/ui/BasicButton.cpp
+    src/ui/TextButton.cpp)
 
 add_custom_command(
     TARGET game POST_BUILD

--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -1,7 +1,7 @@
 #include "Card.hpp"
 
 Card::Card(const Card::VegetableType &type, TextureManager &textureManager)
-    :   Clickable(textureManager.getTexture("card_back")),
+    :   SpriteClickable(textureManager.getTexture("card_back")),
         _backTexture(&textureManager.getTexture("card_back")),
         _type(type)
 {
@@ -47,17 +47,17 @@ Card::Card(const Card::VegetableType &type, TextureManager &textureManager)
             break;
     }
     _frontTexture = &textureManager.getTexture("card_" + _name);
-    _sprite.setScale({0.309f, 0.309f}); // Scale to fit the window
+    _sprite.setScale({CARD_SPRITE_SCALE, CARD_SPRITE_SCALE}); // Scale to fit the window
 
     _border.setSize({_sprite.getGlobalBounds().size.x, _sprite.getGlobalBounds().size.y});
     _border.setOutlineColor(sf::Color::Yellow);
     _border.setOutlineThickness(2.f);
     _border.setFillColor(sf::Color::Transparent);
     setOnClick([this](Clickable&){
-            click();
+        click(MouseClickState::PRESSED);
     });
     setOnClickRelease([this](Clickable&){
-        click();
+        click(MouseClickState::RELEASED);
     });
     setOnDoubleClick([this](Clickable&){
         flipCard();
@@ -69,6 +69,16 @@ Card::Card(const Card::VegetableType &type, TextureManager &textureManager)
 
 Card::~Card()
 {
+}
+
+void Card::init()
+{
+}
+
+void Card::updateScale(const float &scale)
+{    
+    _sprite.setScale({scale, scale});
+    _border.setSize({_sprite.getGlobalBounds().size.x, _sprite.getGlobalBounds().size.y});
 }
 
 void Card::setOnClick(ClickCallback callback)
@@ -121,13 +131,21 @@ void Card::setClickState(ClickState state)
     _clickState = state;
 }
 
-void Card::click()
+void Card::click(MouseClickState clickState)
 {
-    if (this->getClickState() == ClickState::NONE)
+    if (clickState == MouseClickState::PRESSED)
     {
-        this->setClickState(ClickState::PRESSED);
-        _isClicked = true;
-        _border.setPosition(_sprite.getPosition());
+        if (this->getClickState() == ClickState::NONE)
+        {
+            this->setClickState(ClickState::PRESSED);
+            _isClicked = true;
+            _border.setPosition(_sprite.getPosition());
+        }
+        else
+        {
+            this->setClickState(ClickState::NONE);
+            _isClicked = false;
+        }
     }
     else
     {

--- a/src/Card.hpp
+++ b/src/Card.hpp
@@ -6,10 +6,10 @@
 #include <string>
 #include <optional>
 #include <functional>
-#include "Clickable.hpp"
+#include "SpriteClickable.hpp"
 #include "TextureManager.hpp"
 
-class Card : public Clickable
+class Card : public SpriteClickable
 {
 public:
     enum class VegetableType {
@@ -48,16 +48,24 @@ public:
     Card(const Card::VegetableType& type, TextureManager& textureManager);
     ~Card();
 
+    virtual void init() override;
+
+    // Getters
+    const VegetableType& getType() const { return _type; }
+
+    // Sprite and Position
+    void updateScale(const float& scale);
+
     // Callbacks
     void setOnClick(ClickCallback callback);
     void setOnClickRelease(ClickReleaseCallback callback);
     void setOnDoubleClick(ClickCallback callback);
 
     // Event Handling
-    void handleEvent(const sf::Event& event, const sf::RenderWindow& window);
+    virtual void handleEvent(const sf::Event& event, const sf::RenderWindow& window) override;
     void flipCard();
     void setClickState(ClickState state);
-    void click();
+    virtual void click(MouseClickState clickState) override;
 
     // Display
     void showFront();

--- a/src/CardManager.cpp
+++ b/src/CardManager.cpp
@@ -1,0 +1,50 @@
+#include "lib/Random.hpp"
+#include "CardManager.hpp"
+
+CardManager::CardManager(TextureManager &textureManager)
+    : _textureManager(&textureManager)
+{
+}
+
+CardManager::~CardManager()
+{
+}
+
+void CardManager::init()
+{
+    _remainingCardsToCreate[Card::VegetableType::ARTICHOKE] = NB_CARDS_ARTICHOKE;
+    _remainingCardsToCreate[Card::VegetableType::ONION] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::CORN] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::POTATO] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::EGGPLANT] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::PEAS] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::CARROT] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::BROCCOLI] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::LEEK] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::RHUBARB] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::BELLPEPPER] = NB_CARDS_PER_TYPE;
+    _remainingCardsToCreate[Card::VegetableType::BEETROOT] = NB_CARDS_PER_TYPE;
+}
+
+Card *CardManager::createCard()
+{
+    std::uniform_int_distribution<int> distribution(1, 11);
+    Card::VegetableType type;
+    
+    do
+    {
+        type = static_cast<Card::VegetableType>(distribution(Random::engine()));
+    } while (_remainingCardsToCreate[type] == 0);
+    _remainingCardsToCreate[type] -= 1;
+
+    return new Card(type, *_textureManager);
+}
+
+Card *CardManager::createCard(const Card::VegetableType &type)
+{
+    if (_remainingCardsToCreate[type] > 0) {
+        _remainingCardsToCreate[type] -= 1;
+        return new Card(type, *_textureManager);
+    }
+    return nullptr;
+}

--- a/src/CardManager.hpp
+++ b/src/CardManager.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <string>
+#include <map>
+#include "SpriteClickable.hpp"
+#include "Card.hpp"
+
+class CardManager {
+protected:
+    std::map<Card::VegetableType, int> _remainingCardsToCreate; // Map to keep track of the number of each type of card in the deck
+
+    TextureManager* _textureManager;
+
+public:
+    CardManager(TextureManager& textureManager);
+    ~CardManager();
+
+    void init();
+
+    Card* createCard();
+    Card* createCard(const Card::VegetableType& type);
+};

--- a/src/Clickable.hpp
+++ b/src/Clickable.hpp
@@ -2,6 +2,8 @@
 
 #include <SFML/Graphics.hpp>
 #include <functional>
+#include "lib/Params.hpp"
+#include "lib/Enums.hpp"
 
 class Clickable {
 public:
@@ -14,16 +16,11 @@ public:
         PRESSED
     };
 
-    Clickable(const sf::Texture& texture) : _sprite(texture) {}
+    Clickable() {};
 
     virtual ~Clickable() = default;
     virtual void handleEvent(const sf::Event& event, const sf::RenderWindow& window) = 0;
-
-    virtual sf::Sprite& getSprite() { return _sprite; }
-    virtual sf::FloatRect getGlobalBounds() const { return _sprite.getGlobalBounds(); }
-    virtual sf::Vector2f getPosition() const { return _sprite.getPosition(); }
-    virtual void setPosition(const sf::Vector2f& position) { _sprite.setPosition(position); }
-    virtual sf::RectangleShape& getBorder() { return _border; }
+    virtual void init() = 0;
 
     virtual ClickState getClickState() const { return _clickState; }
     virtual void setClickState(ClickState state) { _clickState = state; }
@@ -32,17 +29,14 @@ public:
     virtual ClickCallback getOnClickRelease() const { return _onClickRelease; }
     virtual ClickCallback getOnDoubleClick() const { return _onDoubleClick; }
     virtual bool isClicked() const { return _isClicked; }
-    virtual bool contains(const sf::Vector2f& point) const { return _sprite.getGlobalBounds().contains(point); }
+    virtual bool contains(const sf::Vector2f& point) = 0;
 
-    virtual void click() = 0;
+    virtual void click(MouseClickState clickState) = 0;
 
 protected:
     ClickCallback _onClick;
     ClickCallback _onClickRelease;
     ClickCallback _onDoubleClick;
-
-    sf::Sprite      _sprite;
-    sf::RectangleShape   _border;
 
     bool            _isClicked = false;
 

--- a/src/Deck.cpp
+++ b/src/Deck.cpp
@@ -1,23 +1,18 @@
 #include "Deck.hpp"
 
-Deck::Deck(InputManager& inputManager, TextureManager& textureManager)
-:   Clickable(textureManager.getTexture("card_back")),
+Deck::Deck(InputManager& inputManager, TextureManager& textureManager, FontManager& fontManager)
+:   SpriteClickable(textureManager.getTexture("card_back")),
     _inputManager(&inputManager),
     _textureManager(&textureManager),
+    _fontManager(&fontManager),
     _deckTexture(&textureManager.getTexture("card_back")),
-    _deckFont("assets/fonts/CreatoDisplay-Regular.otf"),
-    _deckCountText(_deckFont)
+    _deckCountText(fontManager.getFont("CreatoDisplay-Regular"))
 {
-    _cardCounts[Card::VegetableType::ARTICHOKE] = 10;
-
-    _sprite.setPosition({600.f, 800.f});
-    _sprite.setScale({0.309f, 0.309f}); // Scale to fit the window
+    _sprite.setPosition({50.f, 800.f});
+    _sprite.setScale({CARD_SPRITE_SCALE, CARD_SPRITE_SCALE}); // Scale to fit the window
     setOnClick([this](Clickable&){
             this->setClickState(ClickState::PRESSED);
-            Card* drawnCard = drawCard();
-            if (drawnCard) {
-                drawnCard->setPosition({850.f, 800.f});
-            }
+            this->setState(DeckState::PICKINGCARDS);
     });
     setOnClickRelease([this](Clickable&){
             this->setClickState(ClickState::NONE);
@@ -26,30 +21,31 @@ Deck::Deck(InputManager& inputManager, TextureManager& textureManager)
 
 Deck::~Deck()
 {
-    for (auto* card : _drawnCards) {
+    for (auto* card : _cards) {
         delete card;
     }
-    _drawnCards.clear();
+    _cards.clear();
 }
 
-Card* Deck::drawCard()
+void Deck::init()
 {
-    Card::VegetableType drawnType;
-    std::uniform_int_distribution<int> distribution(0, 0); // Currently only one type of card available
-    drawnType = static_cast<Card::VegetableType>(distribution(Random::engine()));
+}
 
-    while (!_cardCounts.contains(drawnType) or _cardCounts[drawnType] <= 0)
-        drawnType = static_cast<Card::VegetableType>(distribution(Random::engine()));
+void Deck::addCard(Card *card)
+{
+    _cards.push_back(std::move(card));
+}
 
-    if (_cardCounts[drawnType] > 0) {
-        _cardCounts[drawnType] -= 1;
-        // Créer une nouvelle carte
-        Card* newCard = new Card(drawnType, *_textureManager);
-        _drawnCards.push_back(newCard);
-        _inputManager->registerClickable(newCard);
-        return newCard;
+Card *Deck::drawRandomCard()
+{
+    std::uniform_int_distribution<int> distribution(0, _cards.size() - 1);
+
+    if (!_cards.empty()) {
+        int randomIndex = distribution(Random::engine());
+        Card* drawnCard = _cards[randomIndex];
+        _cards.erase(_cards.begin() + randomIndex); // Remove the drawn card from the deck
+        return drawnCard;
     }
-
     return nullptr;
 }
 
@@ -67,14 +63,28 @@ void Deck::handleEvent(const sf::Event &event, const sf::RenderWindow &window)
 {
 }
 
-void Deck::click()
+void Deck::click(MouseClickState clickState)
 {
+}
+
+void Deck::draw(sf::RenderTarget &target)
+{
+    if (_cards.empty()) {
+        _sprite.setTexture(_textureManager->getTexture("potager_slot"));
+    }
+    else
+        _sprite.setTexture(*_deckTexture);
+    target.draw(_sprite);
 }
 
 void Deck::drawContent(sf::RenderTarget &target)
 {
+    std::map<Card::VegetableType, int> cardCounts;
+    for (const auto* card : _cards) {
+        cardCounts[card->getType()]++;
+    }
     std::string countText = "Deck Content:\n";
-    for (const auto& [type, count] : _cardCounts) {
+    for (const auto& [type, count] : cardCounts) {
         std::string typeName;
         switch (type) {
             case Card::VegetableType::ARTICHOKE:
@@ -115,6 +125,6 @@ void Deck::drawContent(sf::RenderTarget &target)
     }
     _deckCountText.setString(countText);
     _deckCountText.setCharacterSize(48);
-    _deckCountText.setPosition({ _sprite.getPosition().x - 350.f, _sprite.getPosition().y });
+    _deckCountText.setPosition({50.f, 50.f});
     target.draw(_deckCountText);
 }

--- a/src/Deck.hpp
+++ b/src/Deck.hpp
@@ -3,46 +3,54 @@
 #include <SFML/Graphics.hpp>
 #include <string>
 #include <map>
-#include "Clickable.hpp"
+#include "SpriteClickable.hpp"
 #include "Card.hpp"
+#include "FontManager.hpp"
 #include "TextureManager.hpp"
 #include "InputManager.hpp"
 #include "lib/Random.hpp"
 
-class Deck : public Clickable {
+class Deck : public SpriteClickable {
+    public:
+        enum class DeckState {
+            IDLE,
+            PICKINGCARDS,
+            EMPTYDECK
+        };
     private:
-        std::map<Card::VegetableType, int> _cardCounts;
-        std::vector<Card*> _drawnCards;
+        std::vector<Card*> _cards; // Cards currently in the deck
 
-        InputManager* _inputManager;
+        InputManager*   _inputManager;
         TextureManager* _textureManager;
+        FontManager*    _fontManager;
+        DeckState       _state;
 
         // SFML Attributes
         sf::Texture*    _deckTexture;
-        sf::Font        _deckFont;
-        sf::Text        _deckCountText; // For v0.4.0 only: display number of cards left by type
-
-        // Callbacks
-        // ClickCallback   _onClick;
-        // ClickCallback   _onClickRelease;
+        sf::Text        _deckCountText; // For develop versions only: display number of cards left by type
 
     public:
-        Deck(InputManager& inputManager, TextureManager& textureManager);
+        Deck(InputManager& inputManager, TextureManager& textureManager, FontManager& fontManager);
         ~Deck();
 
-        Card* drawCard();
+        void init();
 
-        const std::vector<Card*>& getDrawnCards() const { return _drawnCards; }
+        void    addCard(Card* card);
+        Card*   drawRandomCard();
+
+        const std::vector<Card*>& getCards() const { return _cards; }
 
         // Callbacks
         void setOnClick(ClickCallback callback);
         void setOnClickRelease(ClickReleaseCallback callback);
 
         // Event Handling
-        void handleEvent(const sf::Event& event, const sf::RenderWindow& window) override;
-        void click();
+        void handleEvent(const sf::Event& event, const sf::RenderWindow& window);
+        void click(MouseClickState clickState);
+        DeckState getState() const { return _state; }
+        void setState(DeckState state) { _state = state; }
 
         // Display
-        void draw(sf::RenderTarget& target) const { target.draw(_sprite); }
+        void draw(sf::RenderTarget& target);
         void drawContent(sf::RenderTarget& target);
 };

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -1,0 +1,28 @@
+#include "FontManager.hpp"
+
+FontManager::FontManager()
+{
+    _fonts["CreatoDisplay-Regular"] = sf::Font("assets/fonts/CreatoDisplay-Regular.otf");
+}
+
+FontManager::~FontManager()
+{
+}
+
+sf::Font& FontManager::getFont(const std::string &key)
+{    
+    if (_fonts.find(key) == _fonts.end()) {
+        throw std::runtime_error("Font not found: " + key);
+    }
+    return _fonts[key];
+}
+
+bool FontManager::loadFont(const std::string &filePath, const std::string &key)
+{
+    sf::Font font;
+    if (!font.openFromFile(filePath)) {
+        return false;
+    }
+    _fonts[key] = font;
+    return true;
+}

--- a/src/FontManager.hpp
+++ b/src/FontManager.hpp
@@ -1,0 +1,17 @@
+# pragma once
+
+#include <SFML/Graphics.hpp>
+#include <unordered_map>
+#include <string>
+
+class FontManager {
+    private:
+        std::unordered_map<std::string, sf::Font> _fonts;
+
+    public:
+        FontManager();
+        ~FontManager();
+
+        sf::Font& getFont(const std::string& filePath);
+        bool loadFont(const std::string& filePath, const std::string& key);
+};

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1,0 +1,148 @@
+#include "Game.hpp"
+
+Game::Game()
+    :   _fontManager(),
+        _textureManager(),
+        _inputManager(),
+        _potager(_textureManager.getTexture("potager_slot")),
+        _deck(_inputManager, _textureManager, _fontManager),
+        _cardManager(_textureManager),
+        _playerHand(_inputManager, _textureManager),
+        _garbage(_inputManager, _textureManager),
+        _endTurnButton("End Turn", _fontManager)
+{
+}
+
+Game::~Game()
+{
+}
+
+void Game::init()
+{
+    _cardManager.init();
+    _inputManager.registerClickable(&_deck);
+    _potager.loadSlots();
+    _playerHand.init();
+    _garbage.init();
+    _endTurnButton.init();
+    _inputManager.registerClickable(&_endTurnButton);
+
+    for (int i = 0; i < 5; i++) {
+        Card* newCard = _cardManager.createCard();
+        _potager.addCard(newCard, i);
+        _inputManager.registerClickable(newCard);
+        newCard->setPosition({ static_cast<float>(350 + i * 250), 400.f });
+    }
+    for (int i = 0; i < 10; i++) {
+        Card* newCard = _cardManager.createCard(Card::VegetableType::ARTICHOKE);
+        _deck.addCard(newCard);
+        _inputManager.registerClickable(newCard);
+    }
+}
+
+void Game::handleEvent(const sf::Event &event, const sf::RenderWindow &window)
+{
+    _inputManager.handleEvent(event, window);
+    retrieveStates();
+}
+
+void Game::retrieveStates()
+{
+    retrievePlayerHandState();
+    retrieveDeckState();
+    retrieveGarbageState();
+    retrieveEndTurnButtonState();
+}
+
+void Game::display(sf::RenderTarget &target)
+{
+    target.clear();
+    _potager.draw(target);
+    _deck.draw(target);
+    _deck.drawContent(target);
+    _playerHand.draw(target);
+    _garbage.draw(target);
+    _endTurnButton.draw(target);
+}
+
+void Game::retrievePlayerHandState()
+{
+    switch(_playerHand.getState())
+    {
+        case PlayerHand::PlayerHandState::IDLE:
+            break;
+        case PlayerHand::PlayerHandState::WAITINGCARDS:
+            break;
+        case PlayerHand::PlayerHandState::DISCARDINGCARDS:
+            while (_playerHand.getCards().size() > 0) {
+                Card* card = _playerHand.discardCard();
+                _garbage.addCard(card);
+            }
+            _playerHand.setState(PlayerHand::PlayerHandState::WAITINGCARDS);
+                break;
+            break;
+    }
+}
+
+void Game::retrieveDeckState()
+{
+    switch(_deck.getState())
+    {
+        case Deck::DeckState::IDLE:
+            break;
+        case Deck::DeckState::PICKINGCARDS:
+            if (_playerHand.getState() == PlayerHand::PlayerHandState::WAITINGCARDS) {
+                for (int i = 0; _playerHand.getCards().size() < 5; i++) {
+                    Card* drawnCard = _deck.drawRandomCard();
+                    if (drawnCard) {
+                        _playerHand.addCard(drawnCard);
+                        drawnCard->setPosition(_playerHand.getSlotPosition(_playerHand.getCards().size() - 1));
+                        drawnCard->updateScale(PLAYER_HAND_SPRITE_SCALE);
+                    }
+                    else
+                    {
+                        _deck.setState(Deck::DeckState::EMPTYDECK);
+                        break;
+                    }
+                }
+                if (_playerHand.getCards().size() >= 5)
+                {
+                    _playerHand.setState(PlayerHand::PlayerHandState::IDLE);
+                    _deck.setState(Deck::DeckState::IDLE);
+                }
+            }
+            else if (_playerHand.getState() == PlayerHand::PlayerHandState::IDLE)
+                _deck.setState(Deck::DeckState::IDLE);
+            break;
+        case Deck::DeckState::EMPTYDECK:
+            for (auto* card : _garbage.getCardsInGarbage())
+                _deck.addCard(_garbage.drawCardFromGarbage());
+            _deck.setState(Deck::DeckState::PICKINGCARDS);
+            break;
+    }
+}
+
+void Game::retrieveGarbageState()
+{
+    switch(_garbage.getState())
+    {
+        case Garbage::GarbageState::IDLE:
+            break;
+        case Garbage::GarbageState::RESTORINGDECK:
+            break;
+    }
+}
+
+void Game::retrieveEndTurnButtonState()
+{
+    switch (_endTurnButton.getClickState())
+    {
+        case Clickable::ClickState::NONE:
+            break;
+        case Clickable::ClickState::PRESSED:
+            // For testing purposes, pressing the end turn button will move all cards from player hand to garbage
+            _playerHand.setState(PlayerHand::PlayerHandState::DISCARDINGCARDS);
+            _endTurnButton.setClickState(Clickable::ClickState::NONE);
+            break;
+    }
+}

--- a/src/Game.hpp
+++ b/src/Game.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "Card.hpp"
+#include "CardManager.hpp"
+#include "Deck.hpp"
+#include "FontManager.hpp"
+#include "Garbage.hpp"
+#include "InputManager.hpp"
+#include "PlayerHand.hpp"
+#include "Potager.hpp"
+#include "TextureManager.hpp"
+#include "ui/TextButton.hpp"
+
+class Game {
+private:
+    InputManager    _inputManager;
+    TextureManager  _textureManager;
+    FontManager     _fontManager;
+    CardManager     _cardManager;
+    Potager         _potager;
+    Deck            _deck;
+    Garbage         _garbage;
+    PlayerHand      _playerHand;
+    TextButton      _endTurnButton;
+
+public:
+    Game();
+    ~Game();
+
+    CardManager& getCardManager() { return _cardManager; }
+    InputManager& getInputManager() { return _inputManager; }
+    TextureManager& getTextureManager() { return _textureManager; }
+    FontManager& getFontManager() { return _fontManager; }
+    Potager& getPotager() { return _potager; }
+    Deck& getDeck() { return _deck; }
+    Garbage& getGarbage() { return _garbage; }
+    PlayerHand& getPlayerHand() { return _playerHand; }
+
+    void init();
+
+    void handleEvent(const sf::Event& event, const sf::RenderWindow& window);
+    void retrieveStates();
+
+    void display(sf::RenderTarget& target);
+
+private:
+    void retrievePlayerHandState();
+    void retrieveDeckState();
+    void retrieveGarbageState();
+    void retrieveEndTurnButtonState();
+};

--- a/src/Garbage.cpp
+++ b/src/Garbage.cpp
@@ -1,0 +1,58 @@
+#include "Garbage.hpp"
+
+Garbage::Garbage(InputManager &inputManager, TextureManager &textureManager)
+: SpriteClickable(textureManager.getTexture("potager_slot")),
+  _inputManager(&inputManager),
+  _textureManager(&textureManager)
+{
+}
+
+Garbage::~Garbage()
+{
+}
+
+void Garbage::init()
+{
+    _sprite.setPosition({ 1500.f, 800.f });
+    _sprite.setScale({CARD_SPRITE_SCALE, CARD_SPRITE_SCALE}); // Scale to fit the window
+}
+
+void Garbage::addCard(Card *card)
+{
+    _cardsInGarbage.push_back(std::move(card));
+    card->setPosition(_sprite.getPosition());
+    card->getSprite().setScale({CARD_SPRITE_SCALE, CARD_SPRITE_SCALE});
+}
+
+Card *Garbage::drawCardFromGarbage()
+{
+    if (!_cardsInGarbage.empty()) {
+        Card* card = _cardsInGarbage.back();
+        _cardsInGarbage.pop_back();
+        return card;
+    }
+    return nullptr;
+}
+
+void Garbage::setOnClick(ClickCallback callback)
+{
+}
+
+void Garbage::setOnClickRelease(ClickReleaseCallback callback)
+{
+}
+
+void Garbage::handleEvent(const sf::Event &event, const sf::RenderWindow &window)
+{
+}
+
+void Garbage::click(MouseClickState clickState)
+{
+}
+
+void Garbage::draw(sf::RenderTarget &target) const
+{
+    target.draw(_sprite);
+    if (!_cardsInGarbage.empty())
+        target.draw(_cardsInGarbage.back()->getSprite());
+}

--- a/src/Garbage.hpp
+++ b/src/Garbage.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <string>
+#include <map>
+#include "SpriteClickable.hpp"
+#include "Card.hpp"
+#include "TextureManager.hpp"
+#include "InputManager.hpp"
+
+class Garbage : public SpriteClickable {
+    public:
+        enum class GarbageState {
+            IDLE,
+            RESTORINGDECK
+        };
+private:
+    std::vector<Card*> _cardsInGarbage;
+
+    InputManager*   _inputManager;
+    TextureManager* _textureManager;
+    GarbageState    _state;
+
+public:
+    Garbage(InputManager& inputManager, TextureManager& textureManager);
+    ~Garbage();
+
+    virtual void init() override;
+
+    void addCard(Card* card);
+    Card* drawCardFromGarbage();
+    const std::vector<Card*>& getCardsInGarbage() const { return _cardsInGarbage; }
+
+    // Callbacks
+    void setOnClick(ClickCallback callback);
+    void setOnClickRelease(ClickReleaseCallback callback);
+
+    // Event Handling
+    virtual void handleEvent(const sf::Event& event, const sf::RenderWindow& window) override;
+    virtual void click(MouseClickState clickState) override;
+    GarbageState getState() const { return _state; }
+    void setState(GarbageState state) { _state = state; }
+
+    // Display
+    void draw(sf::RenderTarget& target) const;
+};

--- a/src/PlayerHand.cpp
+++ b/src/PlayerHand.cpp
@@ -1,0 +1,50 @@
+#include "PlayerHand.hpp"
+
+PlayerHand::PlayerHand(InputManager &inputManager, TextureManager &textureManager)
+: _inputManager(&inputManager), _textureManager(&textureManager)
+{
+}
+
+PlayerHand::~PlayerHand()
+{
+}
+
+void PlayerHand::init()
+{
+    for (int i = 0; i < 5; i++) {
+        sf::Sprite slot(_textureManager->getTexture("potager_slot"));
+        slot.setPosition({ static_cast<float>(350 + i * 200), 850.f });
+        slot.setScale({PLAYER_HAND_SPRITE_SCALE, PLAYER_HAND_SPRITE_SCALE});
+        slot.setColor(sf::Color(255, 255, 255, 64)); // Slightly transparent
+        _slots.push_back(slot);
+    }
+    _state = PlayerHandState::WAITINGCARDS;
+}
+
+void PlayerHand::addCard(Card *card)
+{
+    _cards.push_back(card);
+    _cards.back()->getSprite().setScale({PLAYER_HAND_SPRITE_SCALE, PLAYER_HAND_SPRITE_SCALE});
+}
+
+Card *PlayerHand::discardCard()
+{
+    if (!_cards.empty()) {
+        Card* card = _cards.back();
+        _cards.pop_back();
+        return card;
+    }
+    return nullptr;
+}
+
+void PlayerHand::draw(sf::RenderTarget &target)
+{
+    for (const auto& slot : _slots) {
+        target.draw(slot);
+    }
+    for (const auto& card : _cards) {
+        target.draw(card->getSprite());
+        if (card->isClicked())
+            target.draw(card->getBorder());
+    }
+}

--- a/src/PlayerHand.hpp
+++ b/src/PlayerHand.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <string>
+#include <map>
+#include "SpriteClickable.hpp"
+#include "Card.hpp"
+#include "TextureManager.hpp"
+#include "InputManager.hpp"
+#include "lib/Params.hpp"
+
+class PlayerHand {
+    public:
+        enum class PlayerHandState {
+            IDLE,
+            WAITINGCARDS,
+            DISCARDINGCARDS
+        };
+
+    private:
+        std::vector<Card*> _cards; // Cards currently in the player's hand
+        std::vector<sf::Sprite> _slots;
+
+        InputManager* _inputManager;
+        TextureManager* _textureManager;
+        PlayerHandState _state;
+
+    public:
+        PlayerHand(InputManager& inputManager, TextureManager& textureManager);
+        ~PlayerHand();
+
+        void init();
+
+        void addCard(Card* card);
+        Card* discardCard();
+
+        void setState(PlayerHandState state) { _state = state; }
+        PlayerHandState getState() const { return _state; }
+        const sf::Vector2f  getSlotPosition(int index) const { return _slots[index].getPosition(); }
+        const std::vector<Card*>& getCards() const { return _cards; }
+
+        void draw(sf::RenderTarget& target);
+};

--- a/src/Potager.cpp
+++ b/src/Potager.cpp
@@ -4,7 +4,7 @@
 Potager::Potager(const sf::Texture& slotTexture) 
     :   _slotTexture(const_cast<sf::Texture*>(&slotTexture))
 {
-    _elements = std::vector<Clickable*>(5);
+    _elements = std::vector<SpriteClickable*>(5);
 }
 
 Potager::~Potager() {
@@ -19,13 +19,13 @@ void Potager::loadSlots()
     sf::Sprite slot(*_slotTexture);
     for (int i = 0; i < 5; i++) {
         slot.setPosition({ static_cast<float>(350 + i * 250), 400.f });
-        slot.setScale({0.309f, 0.309f});
+        slot.setScale({CARD_SPRITE_SCALE, CARD_SPRITE_SCALE});
         slot.setColor(sf::Color(255, 255, 255, 64)); // Slightly transparent
         _slots.push_back(slot);
     }
 }
 
-void Potager::addCard(Clickable *card, const int &index)
+void Potager::addCard(SpriteClickable *card, const int &index)
 {
     _elements[index] = card;
 }

--- a/src/Potager.hpp
+++ b/src/Potager.hpp
@@ -2,11 +2,11 @@
 
 // #include <SFML/Graphics.hpp>
 #include <vector>
-#include "Clickable.hpp"
+#include "SpriteClickable.hpp"
 
 class Potager {
 private:
-    std::vector<Clickable*> _elements;
+    std::vector<SpriteClickable*> _elements;
     std::vector<sf::Sprite> _slots;
 
     sf::Texture*            _slotTexture;
@@ -16,9 +16,9 @@ public:
 
     void    loadSlots();
 
-    void    addCard(Clickable* card, const int& index);
+    void    addCard(SpriteClickable* card, const int& index);
     
-    std::vector<Clickable*>& getElements() { return _elements; }
+    std::vector<SpriteClickable*>& getElements() { return _elements; }
 
     // SFML Methods
     void    draw(sf::RenderTarget& target) const;

--- a/src/SpriteClickable.hpp
+++ b/src/SpriteClickable.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Clickable.hpp"
+
+class SpriteClickable : public Clickable {
+    protected:
+
+    sf::Sprite _sprite;
+    sf::RectangleShape _border;
+
+    public:
+        SpriteClickable(const sf::Texture& texture) : _sprite(texture) {}
+        ~SpriteClickable() = default;
+
+        virtual void handleEvent(const sf::Event& event, const sf::RenderWindow& window) = 0;
+        virtual void init() = 0;
+
+        virtual sf::Sprite& getSprite() { return _sprite; }
+        virtual sf::FloatRect getGlobalBounds() const { return _sprite.getGlobalBounds(); }
+        virtual sf::Vector2f getPosition() const { return _sprite.getPosition(); }
+        virtual void setPosition(const sf::Vector2f& position) { _sprite.setPosition(position); }
+        virtual sf::RectangleShape& getBorder() { return _border; }
+
+        virtual bool contains(const sf::Vector2f& point) override { return _sprite.getGlobalBounds().contains(point); };
+};

--- a/src/lib/Enums.hpp
+++ b/src/lib/Enums.hpp
@@ -1,0 +1,12 @@
+# pragma once
+
+enum class MouseClickType {
+    LEFT,
+    RIGHT,
+    MIDDLE
+};
+
+enum class MouseClickState {
+    RELEASED,
+    PRESSED
+};

--- a/src/lib/Params.hpp
+++ b/src/lib/Params.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+# define NB_CARDS_ARTICHOKE 10
+# define NB_CARDS_PER_TYPE 6
+# define CARD_SPRITE_SCALE 0.309f
+# define PLAYER_HAND_SPRITE_SCALE 0.247f
+
+# define BASIC_BUTTON_WIDTH 200.f
+# define BASIC_BUTTON_HEIGHT 50.f
+# define BASIC_BUTTON_COLOR sf::Color{140, 140, 140, 255}
+# define BASIC_BUTTON_HOVER_COLOR sf::Color{170, 170, 170, 255}
+# define BASIC_BUTTON_CLICK_COLOR sf::Color{100, 100, 100, 255}
+# define BASIC_BUTTON_TEXT_COLOR sf::Color::White
+# define BASIC_BUTTON_TEXT_SIZE 24

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,34 +1,18 @@
-#include <SFML/Graphics.hpp>
 #include "lib/Random.hpp"
-#include "Card.hpp"
-#include "Potager.hpp"
-#include "Deck.hpp"
-#include "InputManager.hpp"
-#include "TextureManager.hpp"
+#include "Game.hpp"
 
 int main()
 {
     sf::RenderWindow window(sf::VideoMode({1920, 1200}), "SFML works!", sf::Style::None, sf::State::Fullscreen);
+    sf::CircleShape cursor(3.f);
 
-    InputManager    inputManager;
-    TextureManager  textureManager;
-    Potager         potager(textureManager.getTexture("potager_slot"));
-    Deck            deck(inputManager, textureManager);
-    std::uniform_int_distribution<int> distribution(1, 11);
+    Game game;
 
-    potager.loadSlots();
-
-    for (int i = 0; i < 5; i++) {
-        Card::VegetableType type = static_cast<Card::VegetableType>(distribution(Random::engine()));
-        Card* newCard = new Card(type, textureManager);
-        potager.addCard(newCard, i);
-        inputManager.registerClickable(newCard);
-        newCard->setPosition({ static_cast<float>(350 + i * 250), 400.f });
-    }
-
-    inputManager.registerClickable(&deck);
+    game.init();
 
     window.setKeyRepeatEnabled(false); // Disable key repeat to prevent multiple draws from the deck when holding space
+    window.setMouseCursorVisible(false); // Hide the default mouse cursor
+    cursor.setFillColor(sf::Color::Red);
 
     while (window.isOpen())
     {
@@ -37,16 +21,12 @@ int main()
             if (event->is<sf::Event::Closed>() or sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Escape))
                 window.close();
 
-            inputManager.handleEvent(*event, window);
+            game.handleEvent(*event, window);
+            cursor.setPosition(static_cast<sf::Vector2f>(sf::Mouse::getPosition(window)));
         }
 
-        window.clear();
-        potager.draw(window);
-        deck.draw(window);
-        for (auto* card : deck.getDrawnCards()) {
-            window.draw(card->getSprite());
-        }
-        deck.drawContent(window);
+        game.display(window);
+        window.draw(cursor);
         window.display();
     }
 }

--- a/src/ui/BasicButton.cpp
+++ b/src/ui/BasicButton.cpp
@@ -1,0 +1,41 @@
+#include "BasicButton.hpp"
+
+BasicButton::BasicButton()
+    : Clickable()
+{
+    setOnClick([this](Clickable&){
+        click(MouseClickState::PRESSED);
+    });
+    setOnClickRelease([this](Clickable&){
+        click(MouseClickState::RELEASED);
+    });
+}
+
+void BasicButton::setOnClick(ClickCallback callback)
+{
+    _onClick = std::move(callback);
+}
+
+void BasicButton::setOnClickRelease(ClickReleaseCallback callback)
+{
+    _onClickRelease = std::move(callback);
+}
+
+void BasicButton::init()
+{
+    _buttonShape.setSize({BASIC_BUTTON_WIDTH, BASIC_BUTTON_HEIGHT});
+    _buttonShape.setFillColor(BASIC_BUTTON_COLOR);
+    _buttonShape.setPosition({1700.f, 20.f});
+}
+
+void BasicButton::handleEvent(const sf::Event &event, const sf::RenderWindow &window)
+{
+}
+
+void BasicButton::click(MouseClickState clickState)
+{
+    if (clickState == MouseClickState::PRESSED)
+        setClickState(ClickState::PRESSED);
+    else
+        setClickState(ClickState::NONE);
+}

--- a/src/ui/BasicButton.hpp
+++ b/src/ui/BasicButton.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../lib/Params.hpp"
+#include "../lib/Enums.hpp"
+#include "../Clickable.hpp"
+#include "../InputManager.hpp"
+#include "../TextureManager.hpp"
+
+class BasicButton : public Clickable {
+    protected:
+
+    sf::RectangleShape _buttonShape;
+
+    public:
+        BasicButton();
+        ~BasicButton() = default;
+
+        void setOnClick(ClickCallback callback);
+        void setOnClickRelease(ClickReleaseCallback callback);
+
+        virtual void init() override;
+        virtual void handleEvent(const sf::Event& event, const sf::RenderWindow& window) override;
+        virtual void click(MouseClickState clickState) override;
+        virtual bool contains(const sf::Vector2f& point) override { return _buttonShape.getGlobalBounds().contains(point); };
+
+        void draw(sf::RenderTarget& target) const { target.draw(_buttonShape); }
+};

--- a/src/ui/TextButton.cpp
+++ b/src/ui/TextButton.cpp
@@ -1,0 +1,18 @@
+#include "TextButton.hpp"
+
+TextButton::TextButton(const std::string &text, FontManager& fontManager)
+    : BasicButton(),
+        _fontManager(&fontManager),
+        _buttonText(fontManager.getFont("CreatoDisplay-Regular"))
+{
+    _buttonText.setString(text);
+    _buttonText.setCharacterSize(BASIC_BUTTON_TEXT_SIZE);
+    _buttonText.setFillColor(BASIC_BUTTON_TEXT_COLOR);
+}
+
+void TextButton::init()
+{
+    BasicButton::init();
+    _buttonText.setOrigin({_buttonText.getLocalBounds().size.x / 2.f, _buttonText.getLocalBounds().size.y / 2.f});
+    _buttonText.setPosition({_buttonShape.getPosition().x + BASIC_BUTTON_WIDTH / 2.f, _buttonShape.getPosition().y + BASIC_BUTTON_HEIGHT / 2.f});
+}

--- a/src/ui/TextButton.hpp
+++ b/src/ui/TextButton.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "BasicButton.hpp"
+#include "../FontManager.hpp"
+
+class TextButton : public BasicButton {
+    protected:
+        sf::Text _buttonText;
+
+        FontManager*    _fontManager;
+
+    public:
+        TextButton(const std::string& text, FontManager& fontManager);
+        ~TextButton() = default;
+
+        virtual void init() override;
+
+        void draw(sf::RenderTarget& target) const { target.draw(_buttonShape); target.draw(_buttonText); }
+};


### PR DESCRIPTION
* ci: changed branch trigger (#28)

* feat: created files for Garbage class

* feat: created files for PlayerHand class

* build: added new files to CMake

* fix: new classes declaration

* feat: First prototype of Garbage class

* refactor: Game orchestrator (#29)

* feat: Create Game class files

* build: Add Game class to build

* refactor: Move includes into Game orchestrator

* feat: empty Game class

* refactor: moved InputMgr and TextureMgr under Game orchestrator

* refactor: Moved Potager under Game

* refactor: Move Deck class under Game orchestrator

* style: removed old commented code

* feat: added a cursor

* feat: Game orchestrates init and display of the game

* refactor: code simplification

* feat: CardManager (#30)

* build: Add CardManager source file

* feat: CardManager prototype

* refactor: potager initialization is now done by Game instead of main

* refactor: calling CardManager to create cards for Potager

* refactor: CardManager is now responsible of randomization of new cards

* feat: CardManager creates cards based on its inventory

* refactor: Marked Deck card creation for refactoring

* feat: CardMgr can create a specified card type

* refactor: Deck initialization (#31)

* refactor: add init virtual method in Clickable interface

* refactor: made init method pure on Clickable interface

* feat: hide default cursor

* refactor: Deck no longer creates cards

* test: deck content display

* feat: new position for Deck

* test: deck initialization

* feat: Player Hand (#32)

* feat: player hand class constructor

* refactor: Sprites scales use macros now

* feat: beginning of state machine system

* feat: picking 5 cards from deck to compose player's hand

* fix: border size for player's cards

* feat: Garbage and card zone cycling (#33)

* feat: first garbage protoype with state machine defined

* feat: discarding cards into Garbage

* feat: garbage recycling into Deck

* feat: "End Turn" button discards player's hand into Garbage (#34)

* refactor: Clickable interface no longer contains sf::Sprite, created inherited SpriteClickable interface instead

* feat: created basicButton class

* feat: BasicButton default params

* feat: display a basic button onscreen

* styles: indent fix on Card class

* feat: TextButton creation, inherited from BasicButton class

* feat: add click callbacks on BasicButton class

* feat: FontManager implementation

* feat: Deck and TextButton now use FontManager to retrieve fonts

* styles: remove old code commented

* style: indentation fix

* refactor: clickable objects know now if it's a click or a release

* feat: click on "End Turn" button discard player's cards into Garbage